### PR TITLE
Convert shell.nix into a nix-env spec, remove project-specific deps

### DIFF
--- a/spec/default.nix
+++ b/spec/default.nix
@@ -1,23 +1,28 @@
+# To apply this spec, run: `nix-env -rif spec`
+
 { pkgs ? import ../pkgs.nix {} }:
+
 with pkgs;
 
 let
-  inherit (perlPackages) vidir;
   elixir-erlang-src = runCommand "elixir-erlang-src" {} ''
     mkdir $out
     ln -s ${elixir.src} $out/elixir
     ln -s ${erlang.src} $out/otp
   '';
+
   neovim-with-config = neovim.override {
     configure = {
       customRC = ''
         let g:deoplete#enable_at_startup = 1
-        let g:deoplete#sources#rust#racer_binary='${rustracer}/bin/racer'
-        let g:deoplete#sources#rust#rust_source_path='/home/samrose/Desktop/rust/src'
+        let g:deoplete#sources#rust#racer_binary = "${rustracer}/bin/racer"
+        let g:deoplete#sources#rust#rust_source_path = "${rustc.src}"
         let g:alchemist#elixir_erlang_src = "${elixir-erlang-src}"
+
         set title
         set nu
       '';
+
       packages.package.start = with vimPlugins; [
         alchemist-vim
         deoplete-nvim
@@ -40,23 +45,12 @@ let
   };
 in
 
-mkShell {
-
-
-  buildInputs = [
-    cargo
-    elixir
-    fzf
-    git
-    go
-    gocode
-    go2nix
-    neovim-with-config
-    python
-    python3
-    rustc
-    rustracer
-    which
-  ];
-
-}
+[
+  fzf
+  git
+  gocode
+  neovim-with-config
+  nix # must always be present
+  rustracer
+  which
+]


### PR DESCRIPTION
This is intended to be used with `nix-env -rif`. I've removed project-specific deps. I'm not sure how to best handle Elixir/Erlang/Rust source code, `gocode` and `rustracer` as this kind of things depends on exact versions of compilers, which will be different from project to project.